### PR TITLE
Added authentication method check

### DIFF
--- a/pyswitchvox/client.py
+++ b/pyswitchvox/client.py
@@ -76,7 +76,8 @@ class Client(object):
 
         r = self._session.post("https://" + hostname + "/json", 
                                json={}, 
-                               auth=auth)
+                               auth=auth, 
+                               verify=False)
         if r.status_code == 401:
             auth = requests.auth.HTTPBasicAuth(username, password)
         return auth

--- a/pyswitchvox/client.py
+++ b/pyswitchvox/client.py
@@ -65,9 +65,22 @@ class Client(object):
 
         self._address = address
         self._session = requests.Session()
-        self._session.auth = HTTPDigestAuth(username, password)
+        self._session.auth = self._detect_auth(username, password, address)
         self.timeout = timeout
 
+    def _detect_auth(self, username, password, hostname):
+        """Switchvox 6.6.0.x changed authentication methods.                
+        Returns the request auth object. 
+        """
+        auth = HTTPDigestAuth(username, password)
+
+        r = self._session.post("https://" + hostname + "/json", 
+                               json={}, 
+                               auth=auth)
+        if r.status_code == 401:
+            auth = requests.auth.BasicAuth(username, password))
+        return auth
+    
     def close(self):
         """Close the client connection
         """

--- a/pyswitchvox/client.py
+++ b/pyswitchvox/client.py
@@ -78,7 +78,7 @@ class Client(object):
                                json={}, 
                                auth=auth)
         if r.status_code == 401:
-            auth = requests.auth.BasicAuth(username, password)
+            auth = requests.auth.HTTPBasicAuth(username, password)
         return auth
     
     def close(self):

--- a/pyswitchvox/client.py
+++ b/pyswitchvox/client.py
@@ -78,7 +78,7 @@ class Client(object):
                                json={}, 
                                auth=auth)
         if r.status_code == 401:
-            auth = requests.auth.BasicAuth(username, password))
+            auth = requests.auth.BasicAuth(username, password)
         return auth
     
     def close(self):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools import setup
 
 setup(
     name="pyswitchvox",
-    version="0.0.1",
+    version="0.0.2",
     license="BSD 3-Clause License",
     description="Library for accessing the Switchvox Extend API",
     long_description=open(os.path.join(os.path.dirname(__file__),


### PR DESCRIPTION
Switchvox 6.6.0.x removed HTTPDigestAuth without documenting the change.         
This brakes existing integrations, and renders this library unusable on new installations.

This patch performs a HTTPDigestAuth check using an empty payload, if it receives a 401 error, it returns HTTPBasicAuth method to be used instead.